### PR TITLE
kong: Implement a Kong MVP

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,8 @@
+// Kelda uses AirBnB's JavaScript style guide:
+// https://github.com/airbnb/javascript
+{
+    "extends": "airbnb-base",
+    "parserOptions": {
+        "ecmaVersion": 6
+    }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: node_js
+
+node_js:
+    - 6.9.0
+    - 8.5.0
+
+install:
+    - npm install .
+    - npm install kelda/deployment-engine-downloader && ./node_modules/.bin/kelda-downloader
+
+script:
+    - gulp lint
+    - mkdir -p ~/.kelda/infra/ && mv ./testInfra.js ~/.kelda/infra/default.js
+    - "./kelda inspect ./kongExample.js graphviz"
+
+notifications:
+  slack:
+    secure: Zotg6wCrO23caEkvC22zBHxpmrprn2C4JZ1ibpLDbSd91D2cWxunmDFBSsXMFEo4fpU6JZGzejCRLvmHQau6kDXKt1yWvUyFeySMEfzDIZvXnno+Sq2kCdIghfqYb8hTLaUM7w8GckOVsyaoWysOwNFDrKWuQb12Ga6j/l7h/mFPqo5BQQtpMwCDMJvVmAD9tzpFIxPOLplBY2kxDzurNam4UWqL8TdpXM0VMPR2T+KXmqOR0dPF1LOcTLnZoGYt7fXscPbcx0BxEbnwLGkpWSujXoKVCedoE/MjbrNjRalKnyLJ0DmalgV9Jj1QJlD3htI9RHrrwp35tE/LvENB9ayGVC46beLW6z8zfYhcEozoYqSVN4Cgzw1UpP3mGpcJd1iw+eQLl0+PuKXlTSlLnv/rXgea6PLd/WqZut+cOcxAfI7ud4YMczUF6O6JrYgUihSY15MJVYufY7UxnYp5+eNUGVvNIpfErv8RuNVonYXB4/qDBQ2zr8lrnnjhh2kjLwaLcL51lb+jedsUj66+z1NE7nIx9HuHYcyGrCasrh9bd1bfXMyQ5U7JxIm3kMXf6jpjrXXy8bo53H0kWUxBMerOlwloDft9VHgJRiCuPdrUWgcS3ph0icSuj60qeRvqAZJZBDRfVGMhDMlwP+0lidoRSkaVv74zdHNOJPG6GOs=

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Kelda
+Copyright (c) 2018 Kelda Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,0 +1,88 @@
+[![Build Status](https://travis-ci.org/kelda/kong.svg?branch=master)](https://travis-ci.org/kelda/kong)
+
+# Using Kelda to Launch the Kong Gateway
+
+[Kelda](http://docs.kelda.io) makes it easy to launch and manage a
+[Kong](https://getkong.org/) gateway on any cloud provider.  This repositary
+contains an example Kelda blueprint which describes how to start a colleciotn
+of Kong Gateways.  Once you have [installed
+Kelda](http://docs.kelda.io/#quick-start) you can launch collection of Kong
+gateways by simply running:
+
+```console
+$ kelda run ./sparkRun.js
+```
+
+More details on installation and configuration of this blueprint below.
+
+## Download the blueprint in this repository
+
+Start by cloning this repository and installing the necessary dependencies:
+
+```console
+$ git clone https://github.com/kelda/kong.git
+$ cd kong
+$ npm install .
+```
+
+## Launch a collection of Kong gateways
+
+First start a Kelda daemon:
+
+```console
+$ kelda daemon
+```
+
+The daemon is a long-running process, so you'll need to run future commands in
+a new window (to learn more about the daemon, refer to
+the [Kelda documentation](http://docs.kelda.io)).
+
+The Kelda blueprint in `keldaRun.js` will start an example collection of Kong
+gateways using your default base infrastructure.  If you haven't done so
+already, create a default base infrastructure:
+
+```console
+$ kelda init
+```
+
+For more about creating a Kelda base infrastructure, refer to the
+[Kelda docs](http://docs.kelda.io).
+
+Finally, run the example Kong blueprint:
+
+```console
+$ kelda run ./kongRun.js
+```
+
+This will use the blueprint `kongExample.js` to launch the Kong gateways. It
+will take a bit for the VMs to boot up, for Kelda to configure the network, and
+for Docker containers to be initialized. The command `kelda show` provides
+useful information about the VMs and containers in the deployment.  Once
+everything is up, the `kelda show` output will look something like this:
+
+```console
+MACHINE         ROLE      PROVIDER    REGION       SIZE         PUBLIC IP        STATUS
+i-0b30451866    Master    Amazon      us-west-1    m4.xlarge    54.241.166.50    connected
+i-09de1f5fb0    Worker    Amazon      us-west-1    m4.xlarge    18.144.73.195    connected
+i-05dc503277    Worker    Amazon      us-west-1    m4.xlarge    54.193.77.46     connected
+
+CONTAINER       MACHINE         COMMAND                HOSTNAME    STATUS     CREATED              PUBLIC IP
+0d9a21d2e070    i-05dc503277    postgres:9.5           postgres    running    About an hour ago
+f1924c55d5cb    i-05dc503277    kong                   kong2       running    44 minutes ago       54.193.77.46:[80,8444,443,8001]
+
+b3a5df901769    i-09de1f5fb0    kong sh -c kong ...    migrator    running    44 minutes ago
+b3c53b99877d    i-09de1f5fb0    kong                   kong        running    44 minutes ago       18.144.73.195:[80,443,8001,8444]
+```
+
+At this point, the gateways should be available on port 80 of the public IP
+reported in the kelda show output.
+
+### Caveat
+Note the example blueprint uses a Postgres container hosted on Kelda for the
+Kong database.  In production, you'll want to use a database backed by
+persistent storage to avoid losing data.  In this case, you should tweak
+kongRun.js to point at Amazon RDS, or some other professionally managed
+Postgres instance.
+
+Also, note.  This is a work in progress.  Please file issues, and [contact
+us](kelda.io) with feedback.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,30 @@
+const gulp = require('gulp');
+const gulpIf = require('gulp-if');
+const eslint = require('gulp-eslint');
+
+const lintFiles = ['**/*.js', '!node_modules/**', '!gulpfile.js'];
+
+/**
+ * Determine whether eslint made changes to a gulp file.
+ *
+ * @param {Vinyl} file A gulp file potentially processed by eslint
+ * @return {boolean} Whether eslint fixed the file
+ */
+function isFixed(file) {
+  return file.eslint != null && file.eslint.fixed;
+}
+
+
+gulp.task('default', ['lint']);
+
+gulp.task('lint', () => gulp.src(lintFiles)
+  .pipe(eslint())
+  .pipe(eslint.format()) // Output the lint results to the console.
+  .pipe(eslint.failAfterError()));
+
+gulp.task('lint-fix', () =>
+  gulp.src(lintFiles)
+    .pipe(eslint({ fix: true }))
+    .pipe(eslint.format()) // Output the lint results to the console.
+    .pipe(gulpIf(isFixed, gulp.dest('.'))) // Write the fixed files.
+    .pipe(eslint.failAfterError()));

--- a/kong.js
+++ b/kong.js
@@ -1,0 +1,59 @@
+const kelda = require('kelda');
+
+const listenPort = 80;
+const listenSSLPort = 443;
+
+const adminListenPort = 8001;
+const adminListenSSLPort = 8444;
+
+class Kong {
+  constructor(count, postgres) {
+    this.postgres = postgres;
+    this.kongEnv = {
+      KONG_DATABASE: 'postgres',
+      KONG_PROXY_LISTEN: `0.0.0.0:${listenPort}`,
+      KONG_PROXY_LISTEN_SSL: `0.0.0.0:${listenSSLPort}`,
+      KONG_ADMIN_LISTEN: `0.0.0.0:${adminListenPort}`,
+      KONG_ADMIN_LISTEN_SSL: `0.0.0.0:${adminListenSSLPort}`,
+      KONG_PG_HOST: postgres.getHostname(),
+    };
+
+    this.gateways = [];
+    for (let i = 0; i < count; i += 1) {
+      this.gateways.push(new kelda.Container('kong', 'kong',
+        { env: this.kongEnv }));
+    }
+
+    kelda.allowTraffic(this.gateways, postgres, 5432);
+  }
+
+  // XXX: This is somewhat of a hack.  The first time that a postgres
+  // database is used `kong migrations up` needs to be executed exactly once
+  // (by exactly one node).  In a production deployment, this should probably
+  // be done by a human, but for example deployments this is fine for now.
+  enableMigrator() {
+    this.migrator = new kelda.Container('migrator', 'kong', {
+      command: ['sh', '-c', 'kong migrations up && tail -f /dev/null'],
+      env: this.kongEnv,
+    });
+
+    kelda.allowTraffic(this.migrator, this.postgres, 5432);
+  }
+
+  deploy(deployment) {
+    if (typeof this.migrator !== 'undefined') {
+      this.migrator.deploy(deployment);
+    }
+    this.gateways.forEach(gateway => gateway.deploy(deployment));
+  }
+
+  exposePublic() {
+    kelda.allowTraffic(kelda.publicInternet, this.gateways, listenPort);
+    kelda.allowTraffic(kelda.publicInternet, this.gateways, listenSSLPort);
+    kelda.allowTraffic(kelda.publicInternet, this.gateways, adminListenPort);
+    kelda.allowTraffic(kelda.publicInternet, this.gateways,
+      adminListenSSLPort);
+  }
+}
+
+exports.Kong = Kong;

--- a/kongExample.js
+++ b/kongExample.js
@@ -1,0 +1,19 @@
+const kelda = require('kelda');
+const kong = require('./kong.js');
+
+const inf = kelda.baseInfrastructure();
+
+const workerVMs = inf.machines.filter(machine => machine.role === 'Worker');
+
+const postgres = new kelda.Container('postgres', 'postgres:9.5', {
+  env: {
+    POSTGRES_USER: 'kong',
+    POSTGRES_DB: 'kong',
+  },
+});
+postgres.deploy(inf);
+
+const k = new kong.Kong(workerVMs.length, postgres);
+k.enableMigrator();
+k.exposePublic();
+k.deploy(inf);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@kelda/kong",
+  "version": "0.0.1",
+  "main": "./kong.js",
+  "license": "MIT",
+  "devDependencies": {
+    "eslint": "^4.3.0",
+    "eslint-config-airbnb-base": "^11.3.1",
+    "eslint-plugin-import": "^2.7.0",
+    "gulp": "^3.9.1",
+    "gulp-eslint": "^4.0.0",
+    "gulp-if": "^2.0.2"
+  },
+  "dependencies": {
+    "kelda": ">=0.0.5 <1.0.0"
+  }
+}

--- a/testInfra.js
+++ b/testInfra.js
@@ -1,0 +1,7 @@
+// This file contains the base infrastructure used for the travis build.
+function infraGetter(kelda) {
+  const vmTemplate = new kelda.Machine({ provider: 'Amazon' });
+  return new kelda.Infrastructure(vmTemplate, vmTemplate.replicate(3));
+}
+
+module.exports = infraGetter;


### PR DESCRIPTION
This patch implements a basic Kong blueprint that can get a collection
of Kong gateways up.  These gateways don't do much beyond complaining
about a lack of configuration, but it can be viewed as a starting
point for future development.