### PR TITLE
blueprint: Use new constructor format

### DIFF
--- a/kong.js
+++ b/kong.js
@@ -20,8 +20,11 @@ class Kong {
 
     this.gateways = [];
     for (let i = 0; i < count; i += 1) {
-      this.gateways.push(new kelda.Container('kong', 'kong',
-        { env: this.kongEnv }));
+      this.gateways.push(new kelda.Container({
+        name: 'kong',
+        image: 'kong',
+        env: this.kongEnv,
+      }));
     }
 
     kelda.allowTraffic(this.gateways, postgres, 5432);
@@ -32,7 +35,9 @@ class Kong {
   // (by exactly one node).  In a production deployment, this should probably
   // be done by a human, but for example deployments this is fine for now.
   enableMigrator() {
-    this.migrator = new kelda.Container('migrator', 'kong', {
+    this.migrator = new kelda.Container({
+      name: 'migrator',
+      image: 'kong',
       command: ['sh', '-c', 'kong migrations up && tail -f /dev/null'],
       env: this.kongEnv,
     });

--- a/kongExample.js
+++ b/kongExample.js
@@ -3,9 +3,9 @@ const kong = require('./kong.js');
 
 const inf = kelda.baseInfrastructure();
 
-const workerVMs = inf.machines.filter(machine => machine.role === 'Worker');
-
-const postgres = new kelda.Container('postgres', 'postgres:9.5', {
+const postgres = new kelda.Container({
+  name: 'postgres',
+  image: 'postgres:9.5',
   env: {
     POSTGRES_USER: 'kong',
     POSTGRES_DB: 'kong',
@@ -13,7 +13,7 @@ const postgres = new kelda.Container('postgres', 'postgres:9.5', {
 });
 postgres.deploy(inf);
 
-const k = new kong.Kong(workerVMs.length, postgres);
+const k = new kong.Kong(inf.workers.length, postgres);
 k.enableMigrator();
 k.exposePublic();
 k.deploy(inf);

--- a/testInfra.js
+++ b/testInfra.js
@@ -1,7 +1,10 @@
 // This file contains the base infrastructure used for the travis build.
 function infraGetter(kelda) {
   const vmTemplate = new kelda.Machine({ provider: 'Amazon' });
-  return new kelda.Infrastructure(vmTemplate, vmTemplate.replicate(3));
+  return new kelda.Infrastructure({
+    masters: vmTemplate,
+    workers: vmTemplate.replicate(3),
+  });
 }
 
 module.exports = infraGetter;


### PR DESCRIPTION
The build will fail until the next release of Kelda (0.10.0). This should not be merged until then.